### PR TITLE
update logger info for development & production environment

### DIFF
--- a/clientUpdates/clientUpdates/settings/dev.py
+++ b/clientUpdates/clientUpdates/settings/dev.py
@@ -11,3 +11,40 @@ EMAIL_USE_TLS = True
 EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
 EMAIL_RECIPIENTS = os.getenv('EMAIL_RECIPIENTS', '').split(',')
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '{levelname}; {asctime}; logger name: {name}; module: {module}; msg: {message}',
+            'style': '{',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+        'file': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(LOG_DIR, 'development.log'),
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console', 'file'],
+            'level': 'ERROR',
+            'propagate': True,
+        },
+        'clientUpdates': {
+            'handlers': ['console', 'file'],
+            'level': 'DEBUG',
+            'propagate': False,
+        }
+    },
+}

--- a/clientUpdates/clientUpdates/settings/prod.py
+++ b/clientUpdates/clientUpdates/settings/prod.py
@@ -20,15 +20,23 @@ MIDDLEWARE += ['clientUpdates.middleware.DebugHeadersMiddleware']
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '{levelname}; {asctime}; logger name: {name}; module: {module}; msg: {message}',
+            'style': '{',
+        }
+    },
     'handlers': {
         'console': {
-            'level': 'WARNING',
+            'level': 'INFO',
             'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
         },
         'file': {
-            'level': 'ERROR',
+            'level': 'INFO',
             'class': 'logging.FileHandler',
             'filename': os.path.join(LOG_DIR, 'production.log'),
+            'formatter': 'verbose',
         },
     },
     'loggers': {
@@ -37,5 +45,10 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
+        'clientUpdates': {
+            'handlers': ['console', 'file'],
+            'level': 'DEBUG',
+            'propagate': False,
+        }
     },
 }


### PR DESCRIPTION
The dev.py and prod.py settings files were modified to create a new logger named 'clientUpdates'. Previously, the only named logger was 'django', which I believe is a default in the django framework. 

So, now if a .py file instantiates the 'clientUpdates' logger via logger=logger.getLogger('clientUpdates'), this logger is used to pass info, warnings, errors, etc. as specified in the settings. 

When in development mode, the clientUpdates logger will send information to the development.log file, and when in production mode, the clientUpdates logger will send information to the production.log file. 

The clientUpdates logger logs information in the following way:
'format': '{levelname}; {asctime}; logger name: {name}; module: {module}; msg: {message}'.

An example of what this looks like is below:
INFO; 2025-01-03 14:54:11,304; logger name: clientUpdates; module: handler; msg: PFAS Results updated successfully for Ebersole Property Well 2 (INACTIVE).